### PR TITLE
Support for 'no_proxy' environment variable

### DIFF
--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -81,7 +81,8 @@ module Locomotive::Coal::Resources
 
           faraday.use         FaradayMiddleware::ParseJson, content_type: /\bjson$/
 
-          faraday.adapter     Faraday.default_adapter  # make requests with Net::HTTP
+          # ENV['no_proxy'] ignored in Faraday.default_adapter (Net::HTTP)
+          faraday.adapter :httpclient
         end
       end
 

--- a/locomotivecms_coal.gemspec
+++ b/locomotivecms_coal.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler',    '~> 1.11.2'
   spec.add_development_dependency 'rake',       '~> 10.4.2'
 
+  spec.add_dependency 'httpclient',             '~> 2.7.1'
   spec.add_dependency 'faraday',                '~> 0.9.1'
   spec.add_dependency 'faraday_middleware',     '~> 0.10.0'
   spec.add_dependency 'activesupport',          '~> 4.2.3'


### PR DESCRIPTION
There is a [bug](https://github.com/lostisland/faraday/pull/361) in Faraday to support the 'no_proxy' env variable. I think it is better to change the NetHTTP adapter instead of the HttpClient to fix this issue until they find an stable solution. As you can see, this option was implemented in other [private](http://alexfalkowski.blogspot.com.es/2014/11/ruby-and-noproxy.html) or public projects like [berkshelf-api-client](https://github.com/berkshelf/berkshelf/pull/1393).
