### PR TITLE
Parses returned JSON and thus return proper token

### DIFF
--- a/lib/locomotive/coal/resources/token.rb
+++ b/lib/locomotive/coal/resources/token.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Locomotive::Coal
   module Resources
 
@@ -6,7 +8,7 @@ module Locomotive::Coal
       include Concerns::Request
 
       def get
-        post('tokens', credentials)['token']
+        JSON.parse(post('tokens', credentials))['token']
       end
 
     end


### PR DESCRIPTION
Hello!

There was a bug because what is returned by the server is JSON. If you only read `['token']`, it always returns `token`. First parsing the JSON fixes the issue and the method properly returns the token value.

Best regards,
Max
