### PR TITLE
Convert doubly escaped strings to JSON

### DIFF
--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -32,12 +32,8 @@ module Locomotive::Coal::Resources
           raise Locomotive::Coal::BadRequestError.new(e)
         end
 
-        if response.env.body.class == String
-          response.env.body = JSON.parse(response.env.body)
-        end
-
         if response.success?
-          raw ? response : response.body
+          raw ? response : _parse_response_body(response.body)
         else
           raise Locomotive::Coal::Error.from_response(response)
         end
@@ -51,6 +47,13 @@ module Locomotive::Coal::Resources
       end
 
       private
+
+      def _parse_response_body response_body
+        if response_body.is_a? String
+          response_body = JSON.parse(response_body)
+        end
+        response_body
+      end
 
       def _do_request(action, endpoint, parameters)
         # compatibility with v2.5.x

--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -30,6 +30,10 @@ module Locomotive::Coal::Resources
           raise Locomotive::Coal::BadRequestError.new(e)
         end
 
+        if response.env.body.class == String
+          response.env.body = JSON.parse(response.env.body)
+        end
+
         if response.success?
           raw ? response : response.body
         else

--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Locomotive::Coal::Resources
   module Concerns
 


### PR DESCRIPTION
Whenever I use wagon, I receive some responses (such as the token) by the engine as a JSON string. However, to retrieve the JSON in the string, it first has to be parsed. 

Maybe I have encountered this bug because I've upgraded from locomotive 2 to locomotive 3, but there is absolutely no way of fixing it besides making sure to parse the response if it is a string. 