### PR TITLE
avoiding before accidental lost connection

### DIFF
--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -23,15 +23,24 @@ module Locomotive::Coal::Resources
         max_count = 5
         response = begin
           # Just uncomment following line if you want to trace protocol between wagon & engine live
-          # puts "#{parameters}"     
+          # puts "#{parameters}"
           _do_request(action, "#{uri.path}/#{endpoint}.json", parameters)
         rescue ::Timeout::Error, ::Errno::ETIMEDOUT, Faraday::Error::TimeoutError => e
           if max_count > 0
-            puts "timeout detected, attempts left: #{max_count}\n\n"
+            puts "\n Warning => timeout detected, attempts left: #{max_count}\n\n"
             max_count -= 1
             retry
           else
             raise Locomotive::Coal::TimeoutError.new(e)
+          end
+        rescue HTTPClient::KeepAliveDisconnected => e
+          if max_count > 0
+            puts "\n Warning => HTTPClient::KeepAliveDisconnected exception detected, attempts left: #{max_count}\n\n"
+            max_count -= 1
+            retry
+          else
+            puts "\n Error => HTTPClient::KeepAliveDisconnected exception detected, attempts left zero... raising exception\n\n"
+            raise HTTPClient::KeepAliveDisconnected.new(e)
           end
         rescue Locomotive::Coal::Error
           raise

--- a/lib/locomotive/coal/resources/concerns/request.rb
+++ b/lib/locomotive/coal/resources/concerns/request.rb
@@ -20,10 +20,19 @@ module Locomotive::Coal::Resources
       end
 
       def do_request(action, endpoint, parameters = {}, raw = false)
+        max_count = 5
         response = begin
+          # Just uncomment following line if you want to trace protocol between wagon & engine live
+          # puts "#{parameters}"     
           _do_request(action, "#{uri.path}/#{endpoint}.json", parameters)
         rescue ::Timeout::Error, ::Errno::ETIMEDOUT, Faraday::Error::TimeoutError => e
-          raise Locomotive::Coal::TimeoutError.new(e)
+          if max_count > 0
+            puts "timeout detected, attempts left: #{max_count}\n\n"
+            max_count -= 1
+            retry
+          else
+            raise Locomotive::Coal::TimeoutError.new(e)
+          end
         rescue Locomotive::Coal::Error
           raise
         rescue Exception => e


### PR DESCRIPTION
This is my improvement that I did about year ago.
It's very helpfulf is such case like:

* deploying project with many entries (I've got a project with over 1000 posts & 3000 images)
* syncing large projects
* backuping large projects

If the Wagon losts connections, you count on resuming your deploying process.
You have 5 lucky tries :-)

While you're deploying and hit the lost connection you'll see information like that:

```
timeout detected, attempts left: 5

```